### PR TITLE
Fix validateSignature function

### DIFF
--- a/src/WebhookValidator.ts
+++ b/src/WebhookValidator.ts
@@ -16,7 +16,7 @@ const WebhookValidator = (webhookSecret: string) => {
       `resourcecurrency${currency}`,
       `resourcereference${reference}`,
       `state${state}`,
-    ].join();
+    ].join('');
     const signedPayload = hmacSHA256(joinedPayload, webhookSecret);
     const signature = hex.stringify(signedPayload);
 

--- a/src/__tests__/WebhookValidator.test.ts
+++ b/src/__tests__/WebhookValidator.test.ts
@@ -8,7 +8,7 @@ const webhookPayload = {
     amount: '10.90',
     currency: <Currency>'EUR',
   },
-  signature: '2a4935bffee9338d1b32f4a3474e0eff285bad03141422bb78c5131af6b45870',
+  signature: 'da5d46662744c63f3f22fc1f35243189d46c4721a7d4f7d4ee8216cf809bf16a',
   state: <EventState>'completed',
 };
 


### PR DESCRIPTION
Hello. I'm using this library to integrate with Utrust and it is working great for the most part.
But when I tried to validate the Webhooks coming from Utrust, I noticed that they kept being invalid (as stated by the `validateSignature` function).
So I decided to dive into the code and found that the algorithm presented in https://docs.api.utrust.com/#tag/Webhooks was not being followed. Instead of the payload being simply concatenated, this library is adding commas between the fields.
To fix this, just start concatenating the payload with empty strings.