### PR TITLE
Improve errors returned

### DIFF
--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -51,9 +51,9 @@ const ApiClient = (apiKey: string, environment: Environment = 'production') => {
         },
       )
       .catch((error) => ({
-        status: error?.reponse?.status,
+        status: error?.response?.status,
         data: null,
-        errors: error.response || error.request || error.message,
+        errors: error?.response?.data?.errors,
       }));
 
   const getOrder = (uuid: string) =>
@@ -70,9 +70,9 @@ const ApiClient = (apiKey: string, environment: Environment = 'production') => {
         },
       )
       .catch((error) => ({
-        status: error?.reponse?.status,
+        status: error?.response?.status,
         data: null,
-        errors: error.response || error.request || error.message,
+        errors: error?.response?.data?.errors,
       }));
 
   return { createOrder, getOrder };


### PR DESCRIPTION
The `createOrder` and `getOrder` functions were returning the entire response from `axios` instead of just the array of errors.
Instead, just return the array of errors and abstract the use of `axios` from the user.

Besides this, also fix a typo that was causing the status to always be `undefined` on error.